### PR TITLE
Fix missing organization members relation

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -35,24 +35,6 @@ LANGUAGE sql STABLE AS $$
   select auth.uid() is not null;
 $$;
 
-CREATE OR REPLACE FUNCTION public.is_org_member(target_org_id uuid)
-RETURNS boolean
-LANGUAGE sql STABLE AS $$
-  select exists (
-    select 1 from public.organization_members m
-    where m.org_id = target_org_id and m.user_id = auth.uid()
-  );
-$$;
-
-CREATE OR REPLACE FUNCTION public.is_org_admin(target_org_id uuid)
-RETURNS boolean
-LANGUAGE sql STABLE AS $$
-  select exists (
-    select 1 from public.organization_members m
-    where m.org_id = target_org_id and m.user_id = auth.uid() and m.role in ('owner','admin')
-  );
-$$;
-
 -- updated_at trigger helper
 CREATE OR REPLACE FUNCTION public.set_updated_at()
 RETURNS trigger
@@ -97,6 +79,25 @@ CREATE TABLE IF NOT EXISTS public.organization_members (
   created_at timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY (org_id, user_id)
 );
+
+-- helper functions that depend on organization_members
+CREATE OR REPLACE FUNCTION public.is_org_member(target_org_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE AS $$
+  select exists (
+    select 1 from public.organization_members m
+    where m.org_id = target_org_id and m.user_id = auth.uid()
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_org_admin(target_org_id uuid)
+RETURNS boolean
+LANGUAGE sql STABLE AS $$
+  select exists (
+    select 1 from public.organization_members m
+    where m.org_id = target_org_id and m.user_id = auth.uid() and m.role in ('owner','admin')
+  );
+$$;
 
 -- projects
 CREATE TABLE IF NOT EXISTS public.projects (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move `is_org_member` and `is_org_admin` function definitions to resolve `relation does not exist` error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `LANGUAGE sql` functions `is_org_member` and `is_org_admin` were defined before the `public.organization_members` table, leading to a `42P01: relation "public.organization_members" does not exist` error during schema application. This change reorders the definitions to ensure the table exists before the functions referencing it are created.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8ac6083-5991-4312-aa88-b1d651e071d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8ac6083-5991-4312-aa88-b1d651e071d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

