### PR TITLE
Fix random bytes generation in SQL

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -4,10 +4,11 @@
 BEGIN;
 
 -- 1) Extensions & settings
-CREATE EXTENSION IF NOT EXISTS pgcrypto; -- gen_random_uuid(), gen_random_bytes()
-CREATE EXTENSION IF NOT EXISTS pg_trgm;  -- text search indexing support
+CREATE SCHEMA IF NOT EXISTS extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions; -- gen_random_uuid(), gen_random_bytes()
+CREATE EXTENSION IF NOT EXISTS pg_trgm WITH SCHEMA extensions;  -- text search indexing support
 
-SET search_path = public;
+SET search_path = public, extensions;
 
 -- 2) Types
 DO $$ BEGIN


### PR DESCRIPTION
Configure PostgreSQL extensions for Supabase to resolve `gen_random_bytes` function not found error.

---
<a href="https://cursor.com/background-agent?bcId=bc-df4f45af-6b31-4ac3-8984-f3a4f774529a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df4f45af-6b31-4ac3-8984-f3a4f774529a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

